### PR TITLE
implement correct handling for URLs without given locale

### DIFF
--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -21,7 +21,7 @@ defmodule SetLocale do
   end
 
   defp determine_base_or_default_locale(gettext, requested_locale, default_locale) do
-    [base, _dialect] = String.split(requested_locale, "-")
+    base = hd String.split(requested_locale, "-")
     if (is_locale?(requested_locale) and Enum.member?(supported_locales(gettext), base)), do: base, else: default_locale
   end
 

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -14,66 +14,96 @@ defmodule SetLocaleTest do
     assert SetLocale.init(["a", "b"]) == ["a", "b"]
   end
 
-  test "when no locale is given and a root path is requested, it should redirect and set default locale" do
-    assert Gettext.get_locale(MyGettext) == "en"
-    conn = Phoenix.ConnTest.build_conn(:get, "/", %{}) |> SetLocale.call(@default_options)
-    assert redirected_to(conn) == "/en-gb"
-    assert conn.assigns == %{locale: "en-gb"}
-    assert Gettext.get_locale(MyGettext) == "en-gb"
+  describe "when no locale is given" do
+    test "when a root path is requested, it should redirect and set default locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{}) |> SetLocale.call(@default_options)
+      assert redirected_to(conn) == "/en-gb"
+      assert conn.assigns == %{locale: "en-gb"}
+      assert Gettext.get_locale(MyGettext) == "en-gb"
+    end
+
+    test "when headers contain accept-language, it should redirect to that locale if supported" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+      |> Plug.Conn.put_req_header("accept-language","de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
+      |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/nl"
+    end
+
+    test "when headers contain accept-language but none is accepted, it should redirect to the default locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+      |> Plug.Conn.put_req_header("accept-language","de, fr;q=0.9")
+      |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/en-gb"
+    end
+
+    test "it redirects to a prefix with default locale" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{}) |> SetLocale.call(@default_options)
+      assert redirected_to(conn) == "/en-gb/foo/bar/baz"
+      assert conn.assigns == %{locale: "en-gb"}
+      assert Gettext.get_locale(MyGettext) == "en-gb"
+    end
   end
 
-  test "when no locale is given and headers contain accept-language, it should redirect to that locale if supported" do
-    assert Gettext.get_locale(MyGettext) == "en"
-    conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-    |> Plug.Conn.put_req_header("accept-language","de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
-    |> SetLocale.call(@default_options)
-
-    assert redirected_to(conn) == "/nl"
+  describe "when an unsupported locale is given" do
+    test "it redirects to a prefix with default locale" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"}) |> SetLocale.call(@default_options)
+      assert redirected_to(conn) == "/en-gb/foo/bar/baz"
+    end
   end
 
-  test "when no locale is given and headers contain accept-language but non is accepted, it should redirect to the default locale" do
-    assert Gettext.get_locale(MyGettext) == "en"
-    conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-    |> Plug.Conn.put_req_header("accept-language","de, fr;q=0.9, en-gb;q=0.8, en;q=0.7")
-    |> SetLocale.call(@default_options)
+  describe "when the locale is no locale, but a port of the url" do
+    test "it redirects to a prefix with default locale" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+      |> SetLocale.call(@default_options)
 
-    assert redirected_to(conn) == "/en-gb"
+      assert redirected_to(conn) == "/en-gb/foo/bar"
+    end
+
+    test "when headers contain accept-language, it should redirect to the header locale if supported" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+      |> Plug.Conn.put_req_header("accept-language","de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
+      |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/nl/foo/bar"
+    end
+
+    test "when headers contain accept-language, but none is accepted, it should redirect to the default locale" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+      |> Plug.Conn.put_req_header("accept-language","de, fr;q=0.9")
+      |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/en-gb/foo/bar"
+    end
   end
 
-  test "when no locale is given, it redirects to a prefix with default locale" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{}) |> SetLocale.call(@default_options)
-    assert redirected_to(conn) == "/en-gb/foo/bar/baz"
-    assert conn.assigns == %{locale: "en-gb"}
-    assert Gettext.get_locale(MyGettext) == "en-gb"
-  end
+  describe "when an existing locale is given" do
+    test "with sibling: it should only assign it" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"}) |> SetLocale.call(@default_options)
+      assert conn.assigns == %{locale: "en-gb"}
+      assert conn.status == nil
+      assert Gettext.get_locale(MyGettext) == "en-gb"
+    end
 
+    test "without sibling: it should only assign it" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/nl/foo/bar/baz", %{"locale" => "nl"}) |> SetLocale.call(@default_options)
+      assert conn.status == nil
+      assert conn.assigns == %{locale: "nl"}
+      assert Gettext.get_locale(MyGettext) == "nl"
+    end
 
-  test "when an unsupported locale is given, it redirects to a prefix with default locale" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"}) |> SetLocale.call(@default_options)
-    assert redirected_to(conn) == "/en-gb/foo/bar/baz"
-  end
+    test "it should fallback to parent language when sibling does not exist, ie. nl-be should use nl" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/nl-be/foo/bar/baz", %{"locale" => "nl-be"}) |> SetLocale.call(@default_options)
+      assert redirected_to(conn) == "/nl/foo/bar/baz"
+    end
 
-  test "when an existing locale like en-gb is given, it should only assign it" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"}) |> SetLocale.call(@default_options)
-    assert conn.assigns == %{locale: "en-gb"}
-    assert conn.status == nil
-    assert Gettext.get_locale(MyGettext) == "en-gb"
-  end
-
-  test "when an existing locale like nl is given, it should only assign it" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/nl/foo/bar/baz", %{"locale" => "nl"}) |> SetLocale.call(@default_options)
-    assert conn.status == nil
-    assert conn.assigns == %{locale: "nl"}
-    assert Gettext.get_locale(MyGettext) == "nl"
-  end
-
-  test "it should fallback to a parent language when a sibling does not exist, ie. nl-be should use nl" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/nl-be/foo/bar/baz", %{"locale" => "nl-be"}) |> SetLocale.call(@default_options)
-    assert redirected_to(conn) == "/nl/foo/bar/baz"
-  end
-
-  test "should keep query strings as is" do
-    conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar?foo=bar&baz=true", %{"locale" => "de-at"}) |> SetLocale.call(@default_options)
-    assert redirected_to(conn) == "/en-gb/foo/bar?foo=bar&baz=true"
+    test "should keep query strings as is" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar?foo=bar&baz=true", %{"locale" => "de-at"}) |> SetLocale.call(@default_options)
+      assert redirected_to(conn) == "/en-gb/foo/bar?foo=bar&baz=true"
+    end
   end
 end


### PR DESCRIPTION
There was a small bug, so that URLs like "http://xyz.com/about" were not correctly redirected, but raised an error. That is fixed now.