### PR TITLE
fallback support to language from full language tags in accept-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ When someone uses the url : ```http://www.example.org/foo/bar/baz``` they will b
 
 When someone uses the url : ```http://www.example.org/en-gb/foo/bar/baz``` they will be redirected to ```http://www.example.org/en/foo/bar/baz```
 
-When someone uses an unsupported locale in the url they will be redirect to the default one: ```http://www.example.org/de-de/foo/bar/baz``` they will be redirected to ```http://www.example.org/en/foo/bar/baz```
+When someone uses an unsupported locale in the url they will be redirected to the default one: ```http://www.example.org/de-de/foo/bar/baz``` they will be redirected to ```http://www.example.org/en/foo/bar/baz```
 
-When someone uses a url with no locale prefix, and their browser contains an accept-language string that contains a supported locale they will be redirect to that : ```http://www.example.org/foo/bar/baz``` they will be redirected to ```http://www.example.org/nl-nl/foo/bar/baz```
+When someone uses a url with no locale prefix, and their browser contains an accept-language string that contains a supported locale : ```http://www.example.org/foo/bar/baz``` they will be redirected to ```http://www.example.org/nl-nl/foo/bar/baz```
 
 ## Fallback chain and precedence
 

--- a/lib/headers.ex
+++ b/lib/headers.ex
@@ -8,6 +8,8 @@ defmodule SetLocale.Headers do
         |> Enum.map(&parse_language_option/1)
         |> Enum.sort(&(&1.quality > &2.quality))
         |> Enum.map(&(&1.tag))
+        |> Enum.reject(&is_nil/1)
+        |> ensure_language_fallbacks()
       _ ->
         []
     end
@@ -23,6 +25,20 @@ defmodule SetLocale.Headers do
     end
 
     %{tag: captures["tag"], quality: quality}
+  end
+
+  defp ensure_language_fallbacks(tags) do
+    Enum.flat_map tags, fn tag ->
+      case String.split(tag, "-") do
+        [language, _country_variant] ->
+          if Enum.member?(tags, language) do
+            [tag]
+          else
+            [tag, language]
+          end
+        [_language] -> [tag]
+      end
+    end
   end
 
 end

--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -92,6 +92,4 @@ defmodule SetLocale do
     SetLocale.Headers.extract_accept_language(conn)
     |> Enum.find(nil, fn accepted_locale -> Enum.member?(supported_locales(gettext), accepted_locale) end)
   end
-
-
 end

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -13,9 +13,7 @@ defmodule SetLocaleTest do
   @default_options_with_cookie %SetLocale.Config{gettext: MyGettext, default_locale: "en-gb", cookie_key: @cookie_key}
 
   describe "init" do
-
     test "it supports a legacy config" do
-
       assert SetLocale.init([MyGettext, "en-gb"]) == %SetLocale.Config{gettext: SetLocaleTest.MyGettext, default_locale: "en-gb", cookie_key: nil}
     end
 
@@ -45,6 +43,17 @@ defmodule SetLocaleTest do
       conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
       |> Plug.Conn.fetch_cookies()
       |> Plug.Conn.put_req_header("accept-language","de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
+      |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/nl"
+    end
+
+    test "when headers contain accept-language with full language tags with country variants,
+          it should redirect to the language if country variant is not supported" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+      |> Plug.Conn.fetch_cookies()
+      |> Plug.Conn.put_req_header("accept-language","de, en-gb;q=0.8, nl-nl;q=0.9, en;q=0.7, *;q=0.5")
       |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl"


### PR DESCRIPTION
adds fallback to "nl" if "nl-nl" is given in accept-header