### PR TITLE
make language fallback handle larger language ranges

### DIFF
--- a/lib/headers.ex
+++ b/lib/headers.ex
@@ -29,10 +29,8 @@ defmodule SetLocale.Headers do
 
   defp ensure_language_fallbacks(tags) do
     Enum.flat_map tags, fn tag ->
-      case String.split(tag, "-") do
-        [language, _country_variant] -> if Enum.member?(tags, language), do: [tag], else: [tag, language]
-        [_language] -> [tag]
-      end
+      [language | _] = String.split(tag, "-")
+      if Enum.member?(tags, language), do: [tag], else: [tag, language]
     end
   end
 end

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -81,6 +81,16 @@ defmodule SetLocaleTest do
       assert redirected_to(conn) == "/en-gb"
     end
 
+    test "when headers contain accept-language in incorrect format or language tags with larger range it does not fail" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+             |> Plug.Conn.fetch_cookies()
+             |> Plug.Conn.put_req_header("accept-language", ",, hell#foo-bar-baz-1234%, zh-Hans-CN;q=0.5")
+             |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/en-gb"
+    end
+
     test "it redirects to a prefix with default locale" do
       conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{})
              |> Plug.Conn.fetch_cookies()


### PR DESCRIPTION
before this bugfix an accept-language header like "zh-Hans-CN;q=0.5" led to an error