### PR TITLE
Support Gettext 0.14

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule SetLocale.Mixfile do
   defp deps do
     [
       {:phoenix, "~> 1.3.0"},
-      {:gettext, "~> 0.13.1"},
+      {:gettext, "~> 0.14.0"},
       {:earmark, "~>1.2.0", only: :dev},
       {:ex_doc, "~>0.16.4", only: :dev},
       {:excoveralls, "~> 0.7.3", only: :test},


### PR DESCRIPTION
Hi there!

I really like this package a lot! However, after starting a new greenfield Phoenix application with Gettext 0.14, I got this error:

```
$ mix deps.get
Resolving Hex dependencies...

Failed to use "gettext" (version 0.14.0) because
  set_locale (version 0.2.4) requires ~> 0.13.1
  mix.lock specifies 0.14.0
```

I just bumped the `gettext` version string, and now I'm able to use `set_locale` again. According to [gettext's changelog](https://github.com/elixir-lang/gettext/blob/master/CHANGELOG.md), there's a new per-process locale, but I'm not sure if that would produce any pollution for the plug. Haven't seen anything so far.