### PR TITLE
Ignore cookie if it contains an unsupported locale

### DIFF
--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -126,7 +126,10 @@ defmodule SetLocale do
   defp get_redirect_path(%{query_string: query_string}, path) when query_string != "", do: path <> "?#{query_string}"
   defp get_redirect_path(_conn, path), do: path
 
-  defp get_locale_from_cookie(conn, config), do: conn.cookies[config.cookie_key]
+  defp get_locale_from_cookie(conn, config) do
+    locale = conn.cookies[config.cookie_key]
+    if Enum.member?(supported_locales(config), locale), do: locale
+  end
 
   defp get_locale_from_header(conn, gettext) do
     conn

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -130,6 +130,16 @@ defmodule SetLocaleTest do
 
       assert redirected_to(conn) == "/nl/foo/bar/baz"
     end
+
+    test "when the cookie is an unsupported locale, it should use the default locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+             |> Plug.Conn.put_resp_cookie(@cookie_key, "pl")
+             |> Plug.Conn.fetch_cookies()
+             |> SetLocale.call(@default_options_with_cookie)
+
+      assert redirected_to(conn) == "/en-gb"
+    end
   end
 
 


### PR DESCRIPTION
We used to have a few locales on our website that we later removed. Some users still had cookies with one of those old locales. This would cause an endless loop of redirects: `call` checks that the locale is unsupported and calls `rewrite_path`, `rewrite_path` path chooses the locale from the cookie without validating and redirects, `call` checks that the locale is unsupported and calls `rewrite_path`... and so on.

This PR should fix this issue.