### PR TITLE
Fallback to default locale if determined locale unsupported

### DIFF
--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -153,6 +153,16 @@ defmodule SetLocaleTest do
 
       assert redirected_to(conn) == "/nl/foo/bar/baz"
     end
+
+    test "when the cookie is an unsupported locale, it should use the default locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
+             |> Plug.Conn.put_resp_cookie(@cookie_key, "pl")
+             |> Plug.Conn.fetch_cookies()
+             |> SetLocale.call(@default_options_with_cookie)
+
+       assert redirected_to(conn) == "/en-gb"
+    end
   end
 
 
@@ -174,6 +184,16 @@ defmodule SetLocaleTest do
 
       assert redirected_to(conn) == "/nl/foo/bar"
     end
+
+    test "when headers contain referer with unsupported locale, it should use redirect to the default locale" do
+      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar")
+             |> Plug.Conn.put_req_header("referer", "/pl/origin")
+             |> Plug.Conn.fetch_cookies()
+             |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/en-gb/foo/bar"
+    end
+
 
     test "when headers contain referer without valid locale in the path, it should ignore it and use the default" do
       conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})


### PR DESCRIPTION
We've had some issues with the locale determined from cookie/referrer, which can potentially not be among the supported locales (only the one extracted from `accept-language` was checked against supported locales).

Also, please let me know if you want me to use `mix format` on the whole project, I would glad to do that on a separate branch.

This PR supersedes https://github.com/smeevil/set_locale/pull/16

Thanks @smeevil 
