### PR TITLE
 Introduce additional_locales option

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test,priv}/**/*.{ex,exs}"]
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## 0.2.6 (2019-02-21)
 - Thanks @mtarnovan for fixing a compilation warning
 
-## 0.2.3 (2019-02-21)
+## 0.2.5 (2019-02-21)
 - Thanks @mtarnovan and @ohrite for relaxing the gettext and phoenix dependencies
 - Thanks @narnach for making the locale stick and using the http referer header.
 - bumped deps
 
-## 0.2.2 (2017-09-28)
+## 0.2.4 (2017-09-28)
 - Thanks @dirkholzapfel for bugfixing an accept-language header like "zh-Hans-CN;q=0.5"
-## 0.2.2 (2017-09-28)
+
+## 0.2.3 (2017-09-28)
 - Thanks @dirkholzapfel for adding fallback to "nl" if "nl-nl" is given in accept header
 - reformatted code here and there
 - bumped dependency versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.6 (2019-02-21)
+- Thanks @mtarnovan for fixing a compilation warning
+
 ## 0.2.3 (2019-02-21)
 - Thanks @mtarnovan and @ohrite for relaxing the gettext and phoenix dependencies
 - Thanks @narnach for making the locale stick and using the http referer header.

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ defmodule MyApp.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     ...
-    plug SetLocale, gettext: MyApp.Gettext, default_locale: "en", cookie_key: "project_locale" #cookie_key is optional
+    # cookie_key and additional_locales are optional
+    plug SetLocale, gettext: MyApp.Gettext, default_locale: "en", cookie_key: "project_locale", additional_locales: ["fr", "es"]
   end
 
   ...
 
   scope "/", MyApp do
     pipe_through :browser
-    get "/", PageController, :dummy #you need this entry to support the default root without a locale, it will never be called
+    get "/", PageController, :dummy # you need this entry to support the default root without a locale, it will never be called
   end
 
   scope "/:locale", MyApp do
@@ -60,6 +61,11 @@ defmodule MyApp.Router do
 end
 ```
 
+### Options
+- gettext: mandatory
+- default_locale: mandatory, used as last step in fallback chain
+- cookie_key: optional, if given the value of the cookie is part of the fallback chain
+- additional_locales: optional, if given it allows to whitelist locales that are not defined via Gettext. Possible scenario: You want to use Gettext and some SaaS localization service (e.g. http://bablic.com/) in parallel. Whitelisting these additional languages allows you to have proper routing for the locales and trigger the wanted JS behaviour depending on the assigned locale in your templates.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,20 @@ defmodule MyApp.Router do
     plug :accepts, ["html"]
     ...
     # cookie_key and additional_locales are optional
-    plug SetLocale, gettext: MyApp.Gettext, default_locale: "en", cookie_key: "project_locale", additional_locales: ["fr", "es"]
+    plug(SetLocale,
+      gettext: MyApp.Gettext,
+      default_locale: "en",
+      cookie_key: "project_locale",
+      additional_locales: ["fr", "es"]
+    )
   end
 
   ...
 
   scope "/", MyApp do
     pipe_through :browser
-    get "/", PageController, :dummy # you need this entry to support the default root without a locale, it will never be called
+    # you need this entry to support the default root without a locale, it will never be called
+    get "/", PageController, :dummy
   end
 
   scope "/:locale", MyApp do

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
 config :plug, validate_header_keys_during_test: true
-

--- a/lib/headers.ex
+++ b/lib/headers.ex
@@ -1,5 +1,4 @@
 defmodule SetLocale.Headers do
-
   def extract_accept_language(conn) do
     case Plug.Conn.get_req_header(conn, "accept-language") do
       [value | _] ->
@@ -7,7 +6,7 @@ defmodule SetLocale.Headers do
         |> String.split(",")
         |> Enum.map(&parse_language_option/1)
         |> Enum.sort(&(&1.quality > &2.quality))
-        |> Enum.map(&(&1.tag))
+        |> Enum.map(& &1.tag)
         |> Enum.reject(&is_nil/1)
         |> ensure_language_fallbacks()
 
@@ -19,18 +18,19 @@ defmodule SetLocale.Headers do
   defp parse_language_option(string) do
     captures = Regex.named_captures(~r/^\s?(?<tag>[\w\-]+)(?:;q=(?<quality>[\d\.]+))?$/i, string)
 
-    quality = case Float.parse(captures["quality"] || "1.0") do
-      {val, _} -> val
-      _ -> 1.0
-    end
+    quality =
+      case Float.parse(captures["quality"] || "1.0") do
+        {val, _} -> val
+        _ -> 1.0
+      end
 
     %{tag: captures["tag"], quality: quality}
   end
 
   defp ensure_language_fallbacks(tags) do
-    Enum.flat_map tags, fn tag ->
+    Enum.flat_map(tags, fn tag ->
       [language | _] = String.split(tag, "-")
       if Enum.member?(tags, language), do: [tag], else: [tag, language]
-    end
+    end)
   end
 end

--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -66,9 +66,9 @@ defmodule SetLocale do
 
   defp determine_locale(conn, nil, config) do
     determined_locale =
-      get_locale_from_cookie(conn, config)
-      || get_locale_from_http_referrer(conn)
-      || get_locale_from_header(conn, config)
+      get_locale_from_cookie(conn, config) ||
+        get_locale_from_http_referrer(conn) ||
+        get_locale_from_header(conn, config)
 
     if supported_locale?(determined_locale, config),
       do: determined_locale,
@@ -76,9 +76,9 @@ defmodule SetLocale do
   end
 
   defp determine_locale(conn, requested_locale, config) do
-    base = hd String.split(requested_locale, "-")
+    base = hd(String.split(requested_locale, "-"))
 
-    if (is_locale?(requested_locale) and supported_locale?(base, config)) do
+    if is_locale?(requested_locale) and supported_locale?(base, config) do
       base
     else
       determine_locale(conn, nil, config)
@@ -92,12 +92,13 @@ defmodule SetLocale do
     conn
     |> get_req_header("referer")
     |> case do
-         [referrer] when is_binary(referrer) ->
-           uri = URI.parse(referrer)
-           maybe_extract_locale(uri.path)
-         _ ->
-           nil
-       end
+      [referrer] when is_binary(referrer) ->
+        uri = URI.parse(referrer)
+        maybe_extract_locale(uri.path)
+
+      _ ->
+        nil
+    end
   end
 
   defp supported_locales(config),
@@ -112,9 +113,12 @@ defmodule SetLocale do
     case String.split(request_path, "/") do
       [_, maybe_locale | _] ->
         if is_locale?(maybe_locale), do: maybe_locale, else: nil
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
+
   defp maybe_extract_locale(_), do: nil
 
   defp is_locale?(maybe_locale), do: Regex.match?(~r/^[a-z]{2}(-[a-z]{2})?$/, maybe_locale)
@@ -132,14 +136,16 @@ defmodule SetLocale do
     Phoenix.Controller.redirect(conn, to: path)
   end
 
-  defp get_redirect_path(%{query_string: query_string}, path) when query_string != "", do: path <> "?#{query_string}"
+  defp get_redirect_path(%{query_string: query_string}, path) when query_string != "",
+    do: path <> "?#{query_string}"
+
   defp get_redirect_path(_conn, path), do: path
 
   defp get_locale_from_cookie(conn, config), do: conn.cookies[config.cookie_key]
 
   defp get_locale_from_header(conn, gettext) do
     conn
-    |> SetLocale.Headers.extract_accept_language
+    |> SetLocale.Headers.extract_accept_language()
     |> Enum.find(nil, fn accepted_locale -> supported_locale?(accepted_locale, gettext) end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SetLocale.Mixfile do
   def project do
     [
       app: :set_locale,
-      version: "0.2.5",
+      version: "0.2.6",
       description: "A Phoenix Plug to help with supporting I18n routes (http://www.example.org/de-at/foo/bar/az). Will also set Gettext to the requested locale used in the url when supported by your Gettext.",
       package: package(),
       elixir: "~> 1.7",

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,12 @@ defmodule SetLocale.Mixfile do
     [
       app: :set_locale,
       version: "0.2.6",
-      description: "A Phoenix Plug to help with supporting I18n routes (http://www.example.org/de-at/foo/bar/az). Will also set Gettext to the requested locale used in the url when supported by your Gettext.",
+      description:
+        "A Phoenix Plug to help with supporting I18n routes (http://www.example.org/de-at/foo/bar/az). Will also set Gettext to the requested locale used in the url when supported by your Gettext.",
       package: package(),
       elixir: "~> 1.7",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       preferred_cli_env: [
         coveralls: :test,
@@ -38,7 +39,7 @@ defmodule SetLocale.Mixfile do
       {:gettext, "~>0.14"},
       {:earmark, "~>1.3.1", only: :dev},
       {:ex_doc, ">0.13.1", only: :dev},
-      {:excoveralls, "~> 0.10.5", only: :test},
+      {:excoveralls, "~> 0.10.5", only: :test}
     ]
   end
 
@@ -53,5 +54,4 @@ defmodule SetLocale.Mixfile do
       }
     ]
   end
-
 end

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -9,8 +9,12 @@ defmodule SetLocaleTest do
   end
 
   @cookie_key "locale"
-  @default_options             %SetLocale.Config{gettext: MyGettext, default_locale: "en-gb"}
-  @default_options_with_cookie %SetLocale.Config{gettext: MyGettext, default_locale: "en-gb", cookie_key: @cookie_key}
+  @default_options %SetLocale.Config{gettext: MyGettext, default_locale: "en-gb"}
+  @default_options_with_cookie %SetLocale.Config{
+    gettext: MyGettext,
+    default_locale: "en-gb",
+    cookie_key: @cookie_key
+  }
   @default_options_with_additional_locales %SetLocale.Config{
     gettext: MyGettext,
     default_locale: "en-gb",
@@ -87,24 +91,26 @@ defmodule SetLocaleTest do
     end
   end
 
-
-
   describe "when no locale is given and there is no cookie" do
     test "when a root path is requested, it should redirect to default locale" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb"
     end
 
     test "when headers contain accept-language, it should redirect to that locale if supported" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
-             |> SetLocale.call(@default_options)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl"
     end
@@ -112,38 +118,51 @@ defmodule SetLocaleTest do
     test "when headers contain accept-language with full language tags with country variants,
           it should redirect to the language if country variant is not supported" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, nl-nl;q=0.9, en;q=0.7, *;q=0.5")
-             |> SetLocale.call(@default_options)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header(
+          "accept-language",
+          "de, en-gb;q=0.8, nl-nl;q=0.9, en;q=0.7, *;q=0.5"
+        )
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl"
     end
 
     test "when headers contain accept-language but none is accepted, it should redirect to the default locale" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
-             |> SetLocale.call(@default_options)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb"
     end
 
     test "when headers contain accept-language in incorrect format or language tags with larger range it does not fail" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", ",, hell#foo-bar-baz-1234%, zh-Hans-CN;q=0.5")
-             |> SetLocale.call(@default_options)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header(
+          "accept-language",
+          ",, hell#foo-bar-baz-1234%, zh-Hans-CN;q=0.5"
+        )
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb"
     end
 
     test "it redirects to a prefix with default locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar/baz"
     end
@@ -152,42 +171,46 @@ defmodule SetLocaleTest do
   describe "when no locale is given but there is an cookie" do
     test "when a root path is requested, it should redirect to cookie locale" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options_with_cookie)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl"
     end
 
     test "when headers contain accept-language, it should redirect to cookie locale" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
-             |> SetLocale.call(@default_options_with_cookie)
+
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl"
     end
 
     test "it redirects to a prefix with cookie locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options_with_cookie)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar/baz", %{})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl/foo/bar/baz"
     end
   end
 
-
-
   describe "when an unsupported locale is given and there is no cookie" do
     test "it redirects to a prefix with default locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar/baz"
     end
@@ -195,79 +218,84 @@ defmodule SetLocaleTest do
 
   describe "when an unsupported locale is given but there is a cookie" do
     test "it redirects to a prefix with cookie locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options_with_cookie)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar/baz", %{"locale" => "de-at"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl/foo/bar/baz"
     end
 
     test "when the cookie is an unsupported locale, it should use the default locale" do
       assert Gettext.get_locale(MyGettext) == "en"
-      conn = Phoenix.ConnTest.build_conn(:get, "/", %{})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "pl")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options_with_cookie)
 
-       assert redirected_to(conn) == "/en-gb"
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "pl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
+
+      assert redirected_to(conn) == "/en-gb"
     end
   end
 
-
-
   describe "when the locale is no locale, but a part of the url and there is no cookie" do
     test "it redirects to a prefix with default locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar"
     end
 
     test "when headers contain referer with valid locale in the path, it should use redirect to that locale if supported" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("referer", "/nl/origin")
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("referer", "/nl/origin")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl/foo/bar"
     end
 
     test "when headers contain referer with unsupported locale, it should use redirect to the default locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar")
-             |> Plug.Conn.put_req_header("referer", "/pl/origin")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar")
+        |> Plug.Conn.put_req_header("referer", "/pl/origin")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar"
     end
-
 
     test "when headers contain referer without valid locale in the path, it should ignore it and use the default" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("referer", "/origin")
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("referer", "/origin")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar"
     end
 
-
     test "when headers contain accept-language, it should redirect to the header locale if supported" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, nl;q=0.9, en;q=0.7")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl/foo/bar"
     end
 
     test "when headers contain accept-language, but none is accepted, it should redirect to the default locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar"
     end
@@ -275,32 +303,33 @@ defmodule SetLocaleTest do
 
   describe "when the locale is no locale, but a part of the url and there is a cookie" do
     test "it redirects to a prefix with cookie locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options_with_cookie)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl/foo/bar"
     end
 
     test "when headers contain accept-language, it should redirect to the cookie locale" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
-             |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
-             |> Plug.Conn.fetch_cookies()
-             |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
-             |> SetLocale.call(@default_options_with_cookie)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
+        |> SetLocale.call(@default_options_with_cookie)
 
       assert redirected_to(conn) == "/nl/foo/bar"
     end
   end
 
-
-
   describe "when an existing locale is given" do
     test "with sibling: it should only assign it" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert conn.status == nil
       assert conn.assigns == %{locale: "en-gb"}
@@ -308,9 +337,10 @@ defmodule SetLocaleTest do
     end
 
     test "without sibling: it should only assign it" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/nl/foo/bar/baz", %{"locale" => "nl"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/nl/foo/bar/baz", %{"locale" => "nl"})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert conn.status == nil
       assert conn.assigns == %{locale: "nl"}
@@ -318,17 +348,21 @@ defmodule SetLocaleTest do
     end
 
     test "it should fallback to parent language when sibling does not exist, ie. nl-be should use nl" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/nl-be/foo/bar/baz", %{"locale" => "nl-be"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/nl-be/foo/bar/baz", %{"locale" => "nl-be"})
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/nl/foo/bar/baz"
     end
 
     test "should keep query strings as is" do
-      conn = Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar?foo=bar&baz=true", %{"locale" => "de-at"})
-             |> Plug.Conn.fetch_cookies()
-             |> SetLocale.call(@default_options)
+      conn =
+        Phoenix.ConnTest.build_conn(:get, "/de-at/foo/bar?foo=bar&baz=true", %{
+          "locale" => "de-at"
+        })
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options)
 
       assert redirected_to(conn) == "/en-gb/foo/bar?foo=bar&baz=true"
     end

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -9,15 +9,16 @@ defmodule SetLocaleTest do
   end
 
   @cookie_key "locale"
-  @default_options %SetLocale.Config{gettext: MyGettext, default_locale: "en-gb"}
+  @default_locale "en-gb"
+  @default_options %SetLocale.Config{gettext: MyGettext, default_locale: @default_locale}
   @default_options_with_cookie %SetLocale.Config{
     gettext: MyGettext,
-    default_locale: "en-gb",
+    default_locale: @default_locale,
     cookie_key: @cookie_key
   }
   @default_options_with_additional_locales %SetLocale.Config{
     gettext: MyGettext,
-    default_locale: "en-gb",
+    default_locale: @default_locale,
     additional_locales: ["fr", "es"]
   }
 
@@ -100,7 +101,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb"
+      assert redirected_to(conn) == "/#{@default_locale}"
     end
 
     test "when headers contain accept-language, it should redirect to that locale if supported" do
@@ -140,7 +141,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb"
+      assert redirected_to(conn) == "/#{@default_locale}"
     end
 
     test "when headers contain accept-language in incorrect format or language tags with larger range it does not fail" do
@@ -155,7 +156,7 @@ defmodule SetLocaleTest do
         )
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb"
+      assert redirected_to(conn) == "/#{@default_locale}"
     end
 
     test "it redirects to a prefix with default locale" do
@@ -164,7 +165,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar/baz"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar/baz"
     end
   end
 
@@ -212,7 +213,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar/baz"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar/baz"
     end
   end
 
@@ -236,7 +237,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options_with_cookie)
 
-      assert redirected_to(conn) == "/en-gb"
+      assert redirected_to(conn) == "/#{@default_locale}"
     end
   end
 
@@ -247,7 +248,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar"
     end
 
     test "when headers contain referer with valid locale in the path, it should use redirect to that locale if supported" do
@@ -267,7 +268,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar"
     end
 
     test "when headers contain referer without valid locale in the path, it should ignore it and use the default" do
@@ -277,7 +278,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.put_req_header("referer", "/origin")
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar"
     end
 
     test "when headers contain accept-language, it should redirect to the header locale if supported" do
@@ -297,7 +298,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.put_req_header("accept-language", "de, fr;q=0.9")
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar"
     end
   end
 
@@ -364,7 +365,7 @@ defmodule SetLocaleTest do
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 
-      assert redirected_to(conn) == "/en-gb/foo/bar?foo=bar&baz=true"
+      assert redirected_to(conn) == "/#{@default_locale}/foo/bar?foo=bar&baz=true"
     end
 
     test "it should allow non Gettext locales that are whitelisted via additional_locales option
@@ -376,7 +377,7 @@ defmodule SetLocaleTest do
 
       assert conn.status == nil
       assert conn.assigns == %{locale: "fr"}
-      assert Gettext.get_locale(MyGettext) == "en-gb"
+      assert Gettext.get_locale(MyGettext) == @default_locale
     end
   end
 end


### PR DESCRIPTION
This option allows us to whitelist locales that are not defined via Gettext. Possible scenario: You want to use Gettext and some client side SaaS localization service (e.g. http://bablic.com/) in parallel. Whitelisting these additional languages allows you to have proper routing for the locales and trigger the wanted JS behaviour depending on the assigned locale in your templates.