### PR TITLE
Fix GET /?locale=l calling the dummy action

### DIFF
--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -26,13 +26,14 @@ defmodule SetLocale do
 
   def call(
         %{
+          request_path: request_path,
           params: %{
             "locale" => requested_locale
           }
         } = conn,
         config
       ) do
-    if supported_locale?(requested_locale, config) do
+    if request_path != "/" and supported_locale?(requested_locale, config) do
       Gettext.put_locale(config.gettext, requested_locale)
       assign(conn, :locale, requested_locale)
     else

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -248,6 +248,15 @@ defmodule SetLocaleTest do
 
 
   describe "when an existing locale is given" do
+    test "when a root path is requested, it should redirect to the requested locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{"locale" => "nl"})
+             |> Plug.Conn.fetch_cookies()
+             |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/nl"
+    end
+
     test "with sibling: it should only assign it" do
       conn = Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"})
              |> Plug.Conn.fetch_cookies()


### PR DESCRIPTION
The setup process for this plug requires adding a dummy action for `GET /`, and promises that it will never be called. However, it gets called in one specific case, for requests to `GET /?locale=l` where "l" is a supported locale. This commit ensures that requests to `GET /?locale=l` where "l" is a supported locale will instead redirect to `/l`.

