### PR TITLE
Added support for Phoenix LiveView

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,18 @@ defmodule MyApp.Router do
     pipe_through :browser
     get "/", PageController, :index
     ...
+    # If you are using Phoenix LiveView, use the following:
+    live "/livepage", PageLive, session: [:locale]
   end
+end
+```
+
+### Phoenix LiveView
+You need to set the locale in the mount/2 function of your page
+```elixir
+def mount(session, socket) do
+  Gettext.put_locale(session.locale)
+  ... 
 end
 ```
 

--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -39,6 +39,7 @@ defmodule SetLocale do
         do: Gettext.put_locale(config.gettext, config.default_locale),
         else: Gettext.put_locale(config.gettext, requested_locale)
       assign(conn, :locale, requested_locale)
+      put_session(conn, :locale, requested_locale)
     else
       path = rewrite_path(conn, requested_locale, config)
 


### PR DESCRIPTION
To get set_locale working with Phoenix LiveView, the locale needs to be set to the session (as it's running in another thread and Gettext is threadlocal).

Please consider if you like this addition :)