### PR TITLE
Redirect only for GET method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 This phoenix plug will help you with I18n url paths.
-It can extract the preffered locale from the browsers accept-language header and redirect if an url without locale has been given.
+It can extract the preffered locale from the browsers accept-language header and redirect if an url without locale has been given (only for GET method).
 It will extract the locale from the url and check if that is valid and supported. If so it will assign it to ```conn.assigns.locale``` and set ```Gettext``` to that locale as well.
 If it is not supported it will redirect to the default locale.
 

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -389,4 +389,49 @@ defmodule SetLocaleTest do
       assert Gettext.get_locale(MyGettext) == @default_locale
     end
   end
+
+  describe "when the HTTP method is not get or head" do
+    test "POST not redirected" do
+      conn =
+        Phoenix.ConnTest.build_conn(:post, "/foo/bar")
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> SetLocale.call(@default_options_with_cookie)
+
+      assert conn.status == nil
+    end
+
+    test "PUT not redirected" do
+      conn =
+        Phoenix.ConnTest.build_conn(:put, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
+        |> SetLocale.call(@default_options_with_cookie)
+
+      assert conn.status == nil
+    end
+
+    test "PATCH not redirected" do
+      conn =
+        Phoenix.ConnTest.build_conn(:path, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
+        |> SetLocale.call(@default_options_with_cookie)
+
+      assert conn.status == nil
+    end
+
+    test "HEAD redirected" do
+      conn =
+        Phoenix.ConnTest.build_conn(:head, "/foo/bar", %{"locale" => "foo"})
+        |> Plug.Conn.put_resp_cookie(@cookie_key, "nl")
+        |> Plug.Conn.fetch_cookies()
+        |> Plug.Conn.put_req_header("accept-language", "de, en-gb;q=0.8, en;q=0.7")
+        |> SetLocale.call(@default_options_with_cookie)
+
+      assert redirected_to(conn) == "/nl/foo/bar"
+    end
+  end
 end

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -108,7 +108,7 @@ defmodule SetLocaleTest do
       assert Gettext.get_locale(MyGettext) == "en"
 
       conn =
-        Phoenix.ConnTest.build_conn(:get, "/", %{})
+        Phoenix.ConnTest.build_conn(:head, "/", %{})
         |> Plug.Conn.fetch_cookies()
         |> SetLocale.call(@default_options)
 


### PR DESCRIPTION
When we want use [Pow](https://powauth.com/), in documentation is explain to put this:
```
scope "/" do
    pipe_through :browser

    pow_routes()
    pow_extension_routes()
end
```

but some routes use POST, PATCH... method.
In this case, we must rewrite routes to extract GET to allow i18n with set_locale.
In other way, in my RFC understanding, redirect is only for GET and HEAD : https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html